### PR TITLE
typo in the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ reflect the current status.
 ```
 > git clone https://github.com/basho-labs/thumbs.git
 > cd thumbs
-> bundle exec rackup
+> bundler exec rackup
 ```
 ### Running Tests
 ```
-> bundle exec ruby test/test.rb
+> bundler exec ruby test/test.rb
 ```
 
 ### Manual Testing


### PR DESCRIPTION
Guess I'm the first person to ever attempt to deploy this outside basho - it's 'bundler' not 'bundle'